### PR TITLE
Update on pull #9 - use HTML5 download attribute when available

### DIFF
--- a/csv.php
+++ b/csv.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * DISCLAIMER: Don't use www.highcharts.com/studies/csv-export/csv.php in 
+ * production! This file may be removed at any time.
+ */
+
+$csv = $_POST['csv'];
+$filename = (empty($_POST['filename'])) ? 'chart.csv' : $_POST['filename'];
+
+if ($csv) {
+	header('Content-type: text/csv');
+	header("Content-disposition: attachment;filename=$filename");
+	echo $csv;
+}
+
+?>

--- a/export-csv.js
+++ b/export-csv.js
@@ -17,7 +17,7 @@
             // Options
             dateFormat = options.dateFormat || '%Y-%m-%d %H:%M:%S',
             itemDelimiter = options.itemDelimiter || ',', // use ';' for direct import to Excel
-            lineDelimiter = options.lineDelimeter || '\n';
+            lineDelimiter = options.lineDelimeter || "%0A";
 
         each (this.series, function (series) {
             if (series.options.includeInCSVExport !== false) {
@@ -55,18 +55,19 @@
         return csv;
     };
 
-    // Now we want to add "Download CSV" to the exporting menu. We post the CSV
-    // to a simple PHP script that returns it with a content-type header as a 
-    // downloadable file.
-    // The source code for the PHP script can be viewed at 
-    // https://raw.github.com/highslide-software/highcharts.com/master/studies/csv-export/csv.php
+    // Now we want to add "Download CSV" to the exporting menu.
     if (Highcharts.getOptions().exporting) {
         Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({
             text: Highcharts.getOptions().lang.downloadCSV || "Download CSV",
             onclick: function () {
-                Highcharts.post('http://www.highcharts.com/studies/csv-export/csv.php', {
-                    csv: this.getCSV()
-                });
+                // http://stackoverflow.com/questions/17836273/export-javascript-data-to-csv-file-without-server-interaction
+                var a         = document.createElement('a');
+                a.href        = 'data:attachment/csv,' + this.getCSV();
+                a.target      = '_blank';
+                a.download    = this.title.text + '.csv';
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
             }
         });
     }

--- a/export-csv.js
+++ b/export-csv.js
@@ -58,6 +58,14 @@
     };
 
     // Now we want to add "Download CSV" to the exporting menu.
+    // If supported by the browser we use the download attribute
+    // on an anchor element to tell the browser to return the url
+    // data as a downloadable file.
+    // If the download attribute is not supported we post the CSV
+    // to a simple PHP script that returns it with a content-type
+    // header as a downloadable file.
+    // The source code for the PHP script can be viewed at
+    // https://raw.github.com/highslide-software/highcharts.com/master/studies/csv-export/csv.php
     if (Highcharts.getOptions().exporting) {
         Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({
             text: Highcharts.getOptions().lang.downloadCSV || "Download CSV",
@@ -67,15 +75,15 @@
                     a = document.createElement('a');
 
                 if ("download" in a) { // modern browser - no need to use backend script
-                    a.href = 'data:attachment/csv,' + encodeURIComponent(csv);
+                    a.href = 'data:text/csv;charset=UTF-8,' + encodeURIComponent(csv);
                     a.target = '_blank';
                     a.download = title;
                     document.body.appendChild(a);
                     a.click();
                     a.remove();
                 } else {
-                    Highcharts.post(url, {
-                        csv: csv,
+                    Highcharts.post('http://www.highcharts.com/studies/csv-export/csv.php', {
+                        csv: this.getCSV(),
                         title: title
                     });
                 }

--- a/export-csv.js
+++ b/export-csv.js
@@ -70,6 +70,8 @@
         Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({
             text: Highcharts.getOptions().lang.downloadCSV || "Download CSV",
             onclick: function () {
+                var csv = this.getCSV();
+
                 // http://stackoverflow.com/questions/17836273/export-javascript-data-to-csv-file-without-server-interaction
                 var title = ((this.title || {}).text || 'chart') + '.csv',
                     a = document.createElement('a');
@@ -83,7 +85,7 @@
                     a.remove();
                 } else {
                     Highcharts.post('http://www.highcharts.com/studies/csv-export/csv.php', {
-                        csv: this.getCSV(),
+                        csv: csv,
                         title: title
                     });
                 }

--- a/export-csv.js
+++ b/export-csv.js
@@ -61,13 +61,22 @@
             text: Highcharts.getOptions().lang.downloadCSV || "Download CSV",
             onclick: function () {
                 // http://stackoverflow.com/questions/17836273/export-javascript-data-to-csv-file-without-server-interaction
-                var a         = document.createElement('a');
-                a.href        = 'data:attachment/csv,' + this.getCSV();
-                a.target      = '_blank';
-                a.download    = this.title.text + '.csv';
-                document.body.appendChild(a);
-                a.click();
-                a.remove();
+                var title = ((this.title || {}).text || 'chart') + '.csv',
+                    a = document.createElement('a');
+
+                if ("download" in a) { // modern browser - no need to use backend script
+                    a.href = 'data:attachment/csv,' + encodeURIComponent(csv);
+                    a.target = '_blank';
+                    a.download = title;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                } else {
+                    Highcharts.post(url, {
+                        csv: csv,
+                        title: title
+                    });
+                }
             }
         });
     }

--- a/export-csv.js
+++ b/export-csv.js
@@ -70,23 +70,27 @@
         Highcharts.getOptions().exporting.buttons.contextButton.menuItems.push({
             text: Highcharts.getOptions().lang.downloadCSV || "Download CSV",
             onclick: function () {
+                var title = (this.options.title || {}).text,
+                    exportingCsvOptions = (this.options.exporting || {}).csv || {};
+
+                var url = exportingCsvOptions.url || 'http://www.highcharts.com/studies/csv-export/csv.php';
                 var csv = this.getCSV();
 
                 // http://stackoverflow.com/questions/17836273/export-javascript-data-to-csv-file-without-server-interaction
-                var title = ((this.title || {}).text || 'chart') + '.csv',
+                var filename = (title || 'chart') + '.csv',
                     a = document.createElement('a');
 
                 if ("download" in a) { // modern browser - no need to use backend script
                     a.href = 'data:text/csv;charset=UTF-8,' + encodeURIComponent(csv);
                     a.target = '_blank';
-                    a.download = title;
+                    a.download = filename;
                     document.body.appendChild(a);
                     a.click();
                     a.remove();
                 } else {
-                    Highcharts.post('http://www.highcharts.com/studies/csv-export/csv.php', {
+                    Highcharts.post(url, {
                         csv: csv,
-                        title: title
+                        filename: filename
                     });
                 }
             }


### PR DESCRIPTION
This updates the changes in #9 to check for existence of download attribute on <a> and use the existing server-post if the download attribute doesn't exist.

Also adds support for a custom csv.php url.